### PR TITLE
Change pronounciation source from macmillandictionary.com to dictionaryapi.dev

### DIFF
--- a/et
+++ b/et
@@ -75,10 +75,16 @@ define () {
 }
 
 pronounce () {
-  spell $1 0
+    spell $1 0
 
-  URL="https://www.macmillandictionary.com/dictionary/american/$1"
-  play -q $(echo -n "$(curl -sL $URL)" | sed -E '/data-src-mp3/ !d; s/.*data-src-mp3="(.+\.mp3)".*/\1/')
+    PRONOUNCIATIONS=$(curl -s "https://api.dictionaryapi.dev/api/v2/entries/en/$1" | grep -oP '"audio":"\K[^"]+')
+    for ACCENT in 'uk' 'us' 'au' '.*'; do
+        MP3_URL=$(echo "$PRONOUNCIATIONS" | grep -m 1 "$ACCENT")
+        if [ -n "$MP3_URL" ]; then
+            play "$MP3_URL"
+            break
+        fi
+    done
 }
 
 spell () {


### PR DESCRIPTION
https://www.macmillandictionary.com/ now redirects to https://macmillaneducation.my.salesforce-sites.com/help/

It seems like Macmillan no longer provides a dictionary, so I changed the audio source from it to https://dictionaryapi.dev/, which provides a few more accents as well.